### PR TITLE
Auth refactor merge request

### DIFF
--- a/homeassistant/auth/__init__.py
+++ b/homeassistant/auth/__init__.py
@@ -8,7 +8,7 @@ from collections.abc import Mapping
 from datetime import datetime, timedelta
 from functools import partial
 import time
-from typing import Any, cast, Optional
+from typing import Any, cast
 
 import jwt
 
@@ -479,8 +479,8 @@ class AuthManager:
         else:
             expire_at = None
 
-        validate_token_conditions(user, client_id, client_name, token_type)
-        validate_unique_long_lived_access_token(user, client_name, token_type)
+        _validate_token_conditions(user, client_id, client_name, token_type)
+        _validate_unique_long_lived_access_token(user, client_name, token_type)
 
         return await self._store.async_create_refresh_token(
             user,
@@ -682,12 +682,11 @@ class AuthManager:
         return True
 
 
-def validate_token_conditions(
-        user: models.User,
-        client_id: str | None,
-        client_name: str | None,
-        token_type: str | None,
-
+def _validate_token_conditions(
+    user: models.User,
+    client_id: str | None,
+    client_name: str | None,
+    token_type: str | None,
 ) -> None:
     if user.system_generated != (token_type == models.TOKEN_TYPE_SYSTEM):
         raise ValueError(
@@ -697,18 +696,13 @@ def validate_token_conditions(
     if token_type == models.TOKEN_TYPE_NORMAL and client_id is None:
         raise ValueError("Client is required to generate a refresh token.")
 
-    if (
-        token_type == models.TOKEN_TYPE_LONG_LIVED_ACCESS_TOKEN
-        and client_name is None
-    ):
+    if token_type == models.TOKEN_TYPE_LONG_LIVED_ACCESS_TOKEN and client_name is None:
         raise ValueError("Client_name is required for long-lived access token")
 
 
-def validate_unique_long_lived_access_token(
-        user: models.Users, 
-        client_name: str | None,
-        token_type: str | None
-):
+def _validate_unique_long_lived_access_token(
+    user: models.User, client_name: str | None, token_type: str | None
+) -> None:
     if token_type == models.TOKEN_TYPE_LONG_LIVED_ACCESS_TOKEN:
         for token in user.refresh_tokens.values():
             if (

--- a/homeassistant/auth/auth_store.py
+++ b/homeassistant/auth/auth_store.py
@@ -6,7 +6,7 @@ from datetime import timedelta
 import hmac
 import itertools
 from logging import getLogger
-from typing import Any
+from typing import Any, Optional
 
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr, entity_registry as er
@@ -58,7 +58,7 @@ class AuthStore:
         self._loaded = False
         self._users: dict[str, models.User] = None  # type: ignore[assignment]
         self._groups: dict[str, models.Group] = None  # type: ignore[assignment]
-        self._perm_lookup: PermissionLookup = None  # type: ignore[assignment]
+        self._perm_lookup: Optional[PermissionLookup] = None
         self._store = Store[dict[str, list[dict[str, Any]]]](
             hass, STORAGE_VERSION, STORAGE_KEY, private=True, atomic_writes=True
         )

--- a/homeassistant/auth/auth_store.py
+++ b/homeassistant/auth/auth_store.py
@@ -6,7 +6,7 @@ from datetime import timedelta
 import hmac
 import itertools
 from logging import getLogger
-from typing import Any, Optional
+from typing import Any
 
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr, entity_registry as er
@@ -58,7 +58,7 @@ class AuthStore:
         self._loaded = False
         self._users: dict[str, models.User] = None  # type: ignore[assignment]
         self._groups: dict[str, models.Group] = None  # type: ignore[assignment]
-        self._perm_lookup: Optional[PermissionLookup] = None
+        self._perm_lookup: PermissionLookup | None = None
         self._store = Store[dict[str, list[dict[str, Any]]]](
             hass, STORAGE_VERSION, STORAGE_KEY, private=True, atomic_writes=True
         )

--- a/homeassistant/auth/auth_store.py
+++ b/homeassistant/auth/auth_store.py
@@ -343,51 +343,13 @@ class AuthStore:
         # prevents crashing if user rolls back HA version after a new property
         # was added.
 
-        for group_dict in data.get("groups", []):
-            policy: PolicyType | None = None
-
-            if group_dict["id"] == GROUP_ID_ADMIN:
-                has_admin_group = True
-
-                name = GROUP_NAME_ADMIN
-                policy = system_policies.ADMIN_POLICY
-                system_generated = True
-
-            elif group_dict["id"] == GROUP_ID_USER:
-                has_user_group = True
-
-                name = GROUP_NAME_USER
-                policy = system_policies.USER_POLICY
-                system_generated = True
-
-            elif group_dict["id"] == GROUP_ID_READ_ONLY:
-                has_read_only_group = True
-
-                name = GROUP_NAME_READ_ONLY
-                policy = system_policies.READ_ONLY_POLICY
-                system_generated = True
-
-            else:
-                name = group_dict["name"]
-                policy = group_dict.get("policy")
-                system_generated = False
-
-            # We don't want groups without a policy that are not system groups
-            # This is part of migrating from state 1
-            if policy is None:
-                group_without_policy = group_dict["id"]
-                continue
-
-            groups[group_dict["id"]] = models.Group(
-                id=group_dict["id"],
-                name=name,
-                policy=policy,
-                system_generated=system_generated,
-            )
-
-        # If there are no groups, add all existing users to the admin group.
-        # This is part of migrating from state 2
-        migrate_users_to_admin_group = not groups and group_without_policy is None
+        (
+            has_admin_group,
+            has_user_group,
+            has_read_only_group,
+            migrate_users_to_admin_group,
+            group_without_policy,
+        ) = self._soft_migrate_data(data, groups)
 
         # If we find a no_policy_group, we need to migrate all users to the
         # admin group. We only do this if there are no other groups, as is
@@ -410,92 +372,21 @@ class AuthStore:
             user_group = _system_user_group()
             groups[user_group.id] = user_group
 
-        for user_dict in data["users"]:
-            # Collect the users group.
-            user_groups = []
-            for group_id in user_dict.get("group_ids", []):
-                # This is part of migrating from state 1
-                if group_id == group_without_policy:
-                    group_id = GROUP_ID_ADMIN
-                user_groups.append(groups[group_id])
-
-            # This is part of migrating from state 2
-            if not user_dict["system_generated"] and migrate_users_to_admin_group:
-                user_groups.append(groups[GROUP_ID_ADMIN])
-
-            users[user_dict["id"]] = models.User(
-                name=user_dict["name"],
-                groups=user_groups,
-                id=user_dict["id"],
-                is_owner=user_dict["is_owner"],
-                is_active=user_dict["is_active"],
-                system_generated=user_dict["system_generated"],
-                perm_lookup=perm_lookup,
-                # New in 2021.11
-                local_only=user_dict.get("local_only", False),
-            )
-
-        for cred_dict in data["credentials"]:
-            credential = models.Credentials(
-                id=cred_dict["id"],
-                is_new=False,
-                auth_provider_type=cred_dict["auth_provider_type"],
-                auth_provider_id=cred_dict["auth_provider_id"],
-                data=cred_dict["data"],
-            )
-            credentials[cred_dict["id"]] = credential
-            users[cred_dict["user_id"]].credentials.append(credential)
+        _create_users_from_dict(
+            data,
+            users,
+            groups,
+            group_without_policy,
+            migrate_users_to_admin_group,
+            perm_lookup,
+        )
+        _create_credentials(data, credentials, users)
 
         for rt_dict in data["refresh_tokens"]:
             # Filter out the old keys that don't have jwt_key (pre-0.76)
-            if "jwt_key" not in rt_dict:
-                continue
-
-            created_at = dt_util.parse_datetime(rt_dict["created_at"])
-            if created_at is None:
-                getLogger(__name__).error(
-                    (
-                        "Ignoring refresh token %(id)s with invalid created_at "
-                        "%(created_at)s for user_id %(user_id)s"
-                    ),
-                    rt_dict,
-                )
-                continue
-
-            if (token_type := rt_dict.get("token_type")) is None:
-                if rt_dict["client_id"] is None:
-                    token_type = models.TOKEN_TYPE_SYSTEM
-                else:
-                    token_type = models.TOKEN_TYPE_NORMAL
-
-            # old refresh_token don't have last_used_at (pre-0.78)
-            if last_used_at_str := rt_dict.get("last_used_at"):
-                last_used_at = dt_util.parse_datetime(last_used_at_str)
-            else:
-                last_used_at = None
-
-            token = models.RefreshToken(
-                id=rt_dict["id"],
-                user=users[rt_dict["user_id"]],
-                client_id=rt_dict["client_id"],
-                # use dict.get to keep backward compatibility
-                client_name=rt_dict.get("client_name"),
-                client_icon=rt_dict.get("client_icon"),
-                token_type=token_type,
-                created_at=created_at,
-                access_token_expiration=timedelta(
-                    seconds=rt_dict["access_token_expiration"]
-                ),
-                token=rt_dict["token"],
-                jwt_key=rt_dict["jwt_key"],
-                last_used_at=last_used_at,
-                last_used_ip=rt_dict.get("last_used_ip"),
-                expire_at=rt_dict.get("expire_at"),
-                version=rt_dict.get("version"),
-            )
-            if "credential_id" in rt_dict:
-                token.credential = credentials.get(rt_dict["credential_id"])
-            users[rt_dict["user_id"]].refresh_tokens[token.id] = token
+            token = _create_refresh_token(rt_dict, users, credentials)
+            if token:
+                users[rt_dict["user_id"]].refresh_tokens[token.id] = token
 
         self._groups = groups
         self._users = users
@@ -606,6 +497,67 @@ class AuthStore:
         self._groups = groups
         self._build_token_id_to_user_id()
 
+    def _soft_migrate_data(
+        self, data: dict[str, Any], groups: dict[str, models.Group]
+    ) -> tuple[bool, bool, bool, bool, Any]:
+        has_admin_group = False
+        has_user_group = False
+        has_read_only_group = False
+        group_without_policy = None
+
+        for group_dict in data.get("groups", []):
+            policy: PolicyType | None = None
+
+            if group_dict["id"] == GROUP_ID_ADMIN:
+                has_admin_group = True
+
+                name = GROUP_NAME_ADMIN
+                policy = system_policies.ADMIN_POLICY
+                system_generated = True
+
+            elif group_dict["id"] == GROUP_ID_USER:
+                has_user_group = True
+
+                name = GROUP_NAME_USER
+                policy = system_policies.USER_POLICY
+                system_generated = True
+
+            elif group_dict["id"] == GROUP_ID_READ_ONLY:
+                has_read_only_group = True
+
+                name = GROUP_NAME_READ_ONLY
+                policy = system_policies.READ_ONLY_POLICY
+                system_generated = True
+
+            else:
+                name = group_dict["name"]
+                policy = group_dict.get("policy")
+                system_generated = False
+
+            # We don't want groups without a policy that are not system groups
+            # This is part of migrating from state 1
+            if policy is None:
+                group_without_policy = group_dict["id"]
+                continue
+
+            groups[group_dict["id"]] = models.Group(
+                id=group_dict["id"],
+                name=name,
+                policy=policy,
+                system_generated=system_generated,
+            )
+
+        # If there are no groups, add all existing users to the admin group.
+        # This is part of migrating from state 2
+        migrate_users_to_admin_group = not groups and group_without_policy is None
+        return (
+            has_admin_group,
+            has_user_group,
+            has_read_only_group,
+            migrate_users_to_admin_group,
+            group_without_policy,
+        )
+
 
 def _system_admin_group() -> models.Group:
     """Create system admin group."""
@@ -635,3 +587,107 @@ def _system_read_only_group() -> models.Group:
         policy=system_policies.READ_ONLY_POLICY,
         system_generated=True,
     )
+
+
+def _create_users_from_dict(
+    data: dict[str, Any],
+    users: dict[str, models.User],
+    groups: dict[str, models.Group],
+    group_without_policy: Any,
+    migrate_users_to_admin_group: bool,
+    perm_lookup: PermissionLookup,
+) -> None:
+    for user_dict in data["users"]:
+        # Collect the users group.
+        user_groups = []
+        for group_id in user_dict.get("group_ids", []):
+            # This is part of migrating from state 1
+            if group_id == group_without_policy:
+                group_id = GROUP_ID_ADMIN
+            user_groups.append(groups[group_id])
+
+        # This is part of migrating from state 2
+        if not user_dict["system_generated"] and migrate_users_to_admin_group:
+            user_groups.append(groups[GROUP_ID_ADMIN])
+
+        users[user_dict["id"]] = models.User(
+            name=user_dict["name"],
+            groups=user_groups,
+            id=user_dict["id"],
+            is_owner=user_dict["is_owner"],
+            is_active=user_dict["is_active"],
+            system_generated=user_dict["system_generated"],
+            perm_lookup=perm_lookup,
+            # New in 2021.11
+            local_only=user_dict.get("local_only", False),
+        )
+
+
+def _create_refresh_token(
+    rt_dict: dict[str, Any],
+    users: dict[str, models.User],
+    credentials: dict[str, models.Credentials],
+) -> models.RefreshToken | None:
+    if "jwt_key" not in rt_dict:
+        return None
+
+    created_at = dt_util.parse_datetime(rt_dict["created_at"])
+    if created_at is None:
+        getLogger(__name__).error(
+            (
+                "Ignoring refresh token %(id)s with invalid created_at "
+                "%(created_at)s for user_id %(user_id)s"
+            ),
+            rt_dict,
+        )
+        return None
+
+    if (token_type := rt_dict.get("token_type")) is None:
+        if rt_dict["client_id"] is None:
+            token_type = models.TOKEN_TYPE_SYSTEM
+        else:
+            token_type = models.TOKEN_TYPE_NORMAL
+
+    # old refresh_token don't have last_used_at (pre-0.78)
+    if last_used_at_str := rt_dict.get("last_used_at"):
+        last_used_at = dt_util.parse_datetime(last_used_at_str)
+    else:
+        last_used_at = None
+
+    token = models.RefreshToken(
+        id=rt_dict["id"],
+        user=users[rt_dict["user_id"]],
+        client_id=rt_dict["client_id"],
+        # use dict.get to keep backward compatibility
+        client_name=rt_dict.get("client_name"),
+        client_icon=rt_dict.get("client_icon"),
+        token_type=token_type,
+        created_at=created_at,
+        access_token_expiration=timedelta(seconds=rt_dict["access_token_expiration"]),
+        token=rt_dict["token"],
+        jwt_key=rt_dict["jwt_key"],
+        last_used_at=last_used_at,
+        last_used_ip=rt_dict.get("last_used_ip"),
+        expire_at=rt_dict.get("expire_at"),
+        version=rt_dict.get("version"),
+    )
+    if "credential_id" in rt_dict:
+        token.credential = credentials.get(rt_dict["credential_id"])
+    return token
+
+
+def _create_credentials(
+    data: dict[str, Any],
+    credentials: dict[str, models.Credentials],
+    users: dict[str, models.User],
+) -> None:
+    for cred_dict in data["credentials"]:
+        credential = models.Credentials(
+            id=cred_dict["id"],
+            is_new=False,
+            auth_provider_type=cred_dict["auth_provider_type"],
+            auth_provider_id=cred_dict["auth_provider_id"],
+            data=cred_dict["data"],
+        )
+        credentials[cred_dict["id"]] = credential
+        users[cred_dict["user_id"]].credentials.append(credential)

--- a/homeassistant/auth/permissions/entities.py
+++ b/homeassistant/auth/permissions/entities.py
@@ -48,6 +48,7 @@ def _lookup_domain(
     perm_lookup: PermissionLookup, domains_dict: SubCategoryDict, entity_id: str
 ) -> ValueType | None:
     """Look up entity permissions by domain."""
+    _ = perm_lookup
     return domains_dict.get(entity_id.partition(".")[0])
 
 

--- a/homeassistant/auth/permissions/util.py
+++ b/homeassistant/auth/permissions/util.py
@@ -18,6 +18,7 @@ def lookup_all(
     perm_lookup: PermissionLookup, lookup_dict: SubCategoryDict, object_id: str
 ) -> ValueType:
     """Look up permission for all."""
+    _ = (perm_lookup, object_id)
     # In case of ALL category, lookup_dict IS the schema.
     return cast(ValueType, lookup_dict)
 

--- a/homeassistant/auth/providers/__init__.py
+++ b/homeassistant/auth/providers/__init__.py
@@ -167,20 +167,15 @@ async def load_auth_provider_module(
             f"Unable to load auth provider {provider}: {err}"
         ) from err
 
-    if hass.config.skip_pip or not hasattr(module, "REQUIREMENTS"):
-        return module
-
-    if (processed := hass.data.get(DATA_REQS)) is None:
-        processed = hass.data[DATA_REQS] = set()
-    elif provider in processed:
-        return module
-
-    reqs = module.REQUIREMENTS
-    await requirements.async_process_requirements(
-        hass, f"auth provider {provider}", reqs
-    )
-
-    processed.add(provider)
+    if not hass.config.skip_pip and hasattr(module, "REQUIREMENTS"):
+        processed = hass.data.get(DATA_REQS)
+        if processed is None:
+            processed = hass.data[DATA_REQS] = set()    
+        if provider not in processed:
+            reqs = module.REQUIREMENTS
+            await requirements.async_process_requirements(
+                hass, f"auth provider {provider}", reqs)
+            processed.add(provider)
     return module
 
 

--- a/homeassistant/auth/providers/__init__.py
+++ b/homeassistant/auth/providers/__init__.py
@@ -170,11 +170,12 @@ async def load_auth_provider_module(
     if not hass.config.skip_pip and hasattr(module, "REQUIREMENTS"):
         processed = hass.data.get(DATA_REQS)
         if processed is None:
-            processed = hass.data[DATA_REQS] = set()    
+            processed = hass.data[DATA_REQS] = set()
         if provider not in processed:
             reqs = module.REQUIREMENTS
             await requirements.async_process_requirements(
-                hass, f"auth provider {provider}", reqs)
+                hass, f"auth provider {provider}", reqs
+            )
             processed.add(provider)
     return module
 

--- a/homeassistant/auth/providers/command_line.py
+++ b/homeassistant/auth/providers/command_line.py
@@ -80,14 +80,10 @@ class CommandLineAuthProvider(AuthProvider):
             _LOGGER.error("Error while authenticating %r: %s", username, err)
             raise InvalidAuthError from err
 
-        if process.returncode != 0:
-            _LOGGER.error(
-                "User %r failed to authenticate, command exited with code %d",
-                username,
-                process.returncode,
-            )
-            raise InvalidAuthError
+        _validate_authentication_process(process, username)
+        self._extract_metadata(username, stdout)
 
+    def _extract_metadata(self, username: str, stdout: bytes) -> None:
         if self.config[CONF_META]:
             meta: dict[str, str] = {}
             for _line in stdout.splitlines():
@@ -165,3 +161,13 @@ class CommandLineLoginFlow(LoginFlow):
             ),
             errors=errors,
         )
+
+
+def _validate_authentication_process(process: Any, username: str) -> None:
+    if process.returncode != 0:
+        _LOGGER.error(
+            "User %r failed to authenticate, command exited with code %d",
+            username,
+            process.returncode,
+        )
+        raise InvalidAuthError


### PR DESCRIPTION
### Files that were refactored and the issues present in each of them:

- **homeassistant/auth/auth_store.py**, function __init__: type hint for an argument fixed - PermissionLookup | None instead of PermissionLookup
- **homeassistant/auth/auth_store.py**, function async_load: fixed cognitive complexity of this function (before 200lines long)
- **homeassistant/auth/__init__.py**, function async_create_refresh_token: decreased the cognitive complexity
- **homeassistant/auth/permissions/util.py**, function lookup_all: previously unused parameters used "artificially". Since it is a design choice to have same signatures for a specific subset of functions, no parameters were removed
- **homeassistant/auth/providers/__init__.py**, function load_auth_provider_module: the issue was invariant returns, solution was to revert the logic
- **homeassistant/auth/providers/command_line.py**, function async_validate_login: decreased the cognitive complexity
- **homeassistant/auth/permissions/entities.py**, function _lookup_domain: previously unused parameters used "artificially". Since it is a design choice to have same signatures for a specific subset of functions, no parameters were removed


### Tests to run to check the functionality:
pytest tests/auth/

### Note - false positive by SonarQube:
in the file **homeassistant/auth/providers/homeassistant.py**, function **validate_login**, SonarQube marks the presence of the hardcoded dummy password as a security problem. However, this is a false positive.
explanation of why this is not an issue: The presence of the hardcoded dummy password in this context is not a problem and is actually a good security practice. It helps protect against timing attacks by ensuring that the system's response time is consistent, regardless of whether the username exists in the system.